### PR TITLE
Add missing pkg when doing bosh create-env and bump terraform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:focal
 ENV DEBIAN_FRONTEND "noninteractive"
 ENV ENV TZ=Europe/London
-ENV PACKAGES "zlib1g-dev libssl-dev file awscli unzip curl openssl ca-certificates git jq util-linux gzip bash uuid-runtime coreutils vim tzdata openssh-client gnupg make zip golang rubygems rubygems-integration pwgen python3-pip tree dnsutils build-essential ruby-dev python3-dev libkrb5-dev libmagic-dev tmux iputils-ping"
+ENV PACKAGES "zlibc ruby libxslt1-dev libxml2-dev libreadline8 libreadline-dev libyaml-dev libsqlite3-dev sqlite3 zlib1g-dev libssl-dev file awscli unzip curl openssl ca-certificates git jq util-linux gzip bash uuid-runtime coreutils vim tzdata openssh-client gnupg make zip golang rubygems rubygems-integration pwgen python3-pip tree dnsutils build-essential ruby-dev python3-dev libkrb5-dev libmagic-dev tmux iputils-ping"
 RUN printf "Acquire {\n  HTTP::proxy \"%s\"/;\n  HTTPS::proxy \"%s\"/;\n}\n" ${http_proxy} ${http_proxy} > /etc/apt/apt.conf.d/proxy.conf
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends ${PACKAGES} && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN ln -s /usr/bin/python3 /usr/bin/python
@@ -12,7 +12,7 @@ ENV CF_CLI_VERSION "6.52.0"
 ENV YQ_VERSION "3.2.1"
 ENV GOVC_VERSION "0.23.0"
 ENV CREDHUB_VERSION "2.8.0"
-ENV TERRAFORM_VERSION "0.13.5"
+ENV TERRAFORM_VERSION "0.14.8"
 RUN curl -fL "https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/${CREDHUB_VERSION}/credhub-linux-${CREDHUB_VERSION}.tgz" | tar -zx -C /usr/local/bin
 RUN curl -fL "https://s3-us-west-1.amazonaws.com/cf-cli-releases/releases/v${CF_CLI_VERSION}/cf-cli_${CF_CLI_VERSION}_linux_x86-64.tgz" | tar -zx -C /usr/local/bin
 RUN curl -fL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -o /usr/local/bin/yq


### PR DESCRIPTION
- Add missing libs when "bosh create-env" as mentioned in the below url.
   https://bosh.io/docs/cli-v2-install/#additional-dependencies
- Bump terraform to v0.14.8
