### PR TITLE
Revert "Override the default tar"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,6 @@ RUN apt update && apt upgrade -y && apt install -y --no-install-recommends \
   zlibc \
   lsb-release \
   libarchive-tools \
-  && cp /usr/bin/bsdtar /usr/bin/tar \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Languages
@@ -185,5 +184,5 @@ RUN aws --version \
   && yq -V \
   && ytt --version \
   && session-manager-plugin --version \
-  && tar --version | grep bsd \
+  && bsdtar --version \
   && docker version || echo "Docker Client only"


### PR DESCRIPTION
replacing tar with bsdtar causes error in Ubuntu
```
dpkg-deb: error: tar subprocess returned error exit status 1
dpkg: error processing archive /var/cache/apt/archives/golang-1.19-doc_1.19.3-1longsleep1+focal_all.deb (--unpack):
dpkg-deb --control subprocess returned error exit status 2
tar: Option --warning=no-timestamp is not supported
```

This reverts commit 78be0ce3981444c3b23e33c2f800aff50babe019.